### PR TITLE
🐛fix: search 中无法获取关键字等信息

### DIFF
--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -285,8 +285,8 @@ const SearchTabs = {
 export async function loader({ request }: Route.LoaderArgs) {
     return {
         isLoggedIn: request.headers.get('Cookie')?.includes('is_login=1;') || false,
-        keyword: (await request.formData()).get('keyword') as string | null,
-        tab: (await request.formData()).get('tab') as string | null,
+        keyword: new URL(request.url).searchParams.get('keyword'),
+        tab: new URL(request.url).searchParams.get('tab'),
     };
 }
 
@@ -321,7 +321,7 @@ export default function SearchPage({ loaderData }: Route.ComponentProps) {
         <>
             <NavbarComponent />
 
-            <Container className="mt-2">
+            <Container className="mt-5">
                 <SearchInput keyword={keyword} />
             </Container>
 


### PR DESCRIPTION
# 🐛fix: search 中无法获取关键字等信息

## 总结

此 Pull Request 修复了 search.tsx (/search) 中 loader 无法获取关键字信息

## 解决的 issues

解决了 #82 

## 其他信息

无

## 我已进行以下操作

- [x] 已测试代码
- [x] 使用 npm run prettier 进行了格式化代码
- [ ] 若是新的页面，已在 README 中的开发进度画勾
